### PR TITLE
add implicit conversion for undef to OptionalParam

### DIFF
--- a/src/main/scala/sri/macros/OptionalParam.scala
+++ b/src/main/scala/sri/macros/OptionalParam.scala
@@ -1,30 +1,42 @@
 package sri.macros
 
-import scala.reflect.ClassTag
 import scala.scalajs.js
-import scala.scalajs.js.{Any, UndefOr, UndefOrOps, |}
+import scala.scalajs.js.|
 import scala.scalajs.js.|.Evidence
 
 /**
   * https://github.com/scala-js/scala-js/issues/2714
+  *
   * @tparam A
   */
 abstract sealed class OptionalParam[+A] {
   def foreach[U](f: A => U): Unit
 }
+
 case object OptDefault extends OptionalParam[Nothing] {
   def foreach[U](f: Nothing => U): Unit = ()
 }
+
 @inline final case class OptSpecified[+A](val get: A)
-    extends OptionalParam[A] {
+  extends OptionalParam[A] {
   def foreach[U](f: A => U): Unit = f(get)
 }
 
-sealed abstract class LowPriorityImplicits {
-  implicit def any2undefOrUnion[A, B1, B2](a: A)(
-      implicit ev: Evidence[A, B1 | B2]): OptionalParam[B1 | B2] = {
+sealed abstract class LowPriorityImplicits3 {
+  implicit def any2OptOrUnion[A, B1, B2](a: A)(
+    implicit ev: Evidence[A, B1 | B2]): OptionalParam[B1 | B2] = {
     OptSpecified(a).asInstanceOf[OptionalParam[B1 | B2]]
   }
+}
+
+sealed abstract class LowPriorityImplicits2 extends LowPriorityImplicits3 {
+  implicit def undef2Opt[A](undef: js.UndefOr[A]): OptionalParam[A] =
+    undef.fold[OptionalParam[A]](OptDefault)(OptionalParam.specified)
+}
+
+sealed abstract class LowPriorityImplicits extends LowPriorityImplicits2 {
+  implicit def undef2OptOrUnion[A, B1, B2](undef: js.UndefOr[A])
+                                          (implicit ev: Evidence[A, B1 | B2]): OptionalParam[B1 | B2] = undef2Opt(undef)
 }
 
 object OptionalParam extends LowPriorityImplicits {

--- a/src/test/scala/sri/macros/test/OptionalParamTest.scala
+++ b/src/test/scala/sri/macros/test/OptionalParamTest.scala
@@ -1,0 +1,47 @@
+package sri.macros.test
+
+import org.scalatest.FunSuite
+import sri.macros.{OptDefault, OptSpecified, OptionalParam}
+
+import scala.scalajs.js
+import scala.scalajs.js.{UndefOr, |}
+
+class OptionalParamTest extends FunSuite {
+  test("should plain values") {
+    def fun(value: OptionalParam[Int] = OptDefault) = value
+
+    assert(fun(2) === OptSpecified(2))
+    assert(fun() === OptDefault)
+  }
+
+  test("should handle Unions") {
+    def fun(value: OptionalParam[Int | String] = OptDefault) = value
+
+    assert(fun(2) === OptSpecified(2))
+    assert(fun() === OptDefault)
+  }
+
+  test("should handle UndefOr conversions") {
+    def fun(value: OptionalParam[Int] = OptDefault) = value
+
+    assert(fun(js.undefined) === OptDefault)
+    assert(fun(2) === OptSpecified(2))
+  }
+
+  test("should handle UndefOr Union conversions") {
+    trait AA
+    case class A(v1: String) extends AA
+    case object B
+    def fun(value: OptionalParam[AA | B.type] = OptDefault) = value
+
+    val definedA: UndefOr[A] = A("hello")
+    val definedB: UndefOr[A | B.type] = B
+    val undefinedB: UndefOr[A | B.type] = js.undefined
+    assert(fun(A("hello")) === OptionalParam.specified(A("hello")))
+    assert(fun(js.undefined) === OptDefault)
+    assert(fun(definedA) === OptSpecified(A("hello")))
+    assert(fun(definedB) === OptSpecified(B))
+    assert(fun(undefinedB) === OptDefault)
+    assertDoesNotCompile("fun(\"hello\")")
+  }
+}


### PR DESCRIPTION
This PR adds support for implicitly converting any undefs to OptionalParam's it also adds test's for those conversions along with ones for the original conversions